### PR TITLE
Fixes the nap sleep selection bug

### DIFF
--- a/oura/oura_post_to_influxdb.py
+++ b/oura/oura_post_to_influxdb.py
@@ -1,5 +1,4 @@
 #!/bin/python3
-
 from datetime import datetime, timedelta
 from influxdb import InfluxDBClient
 import requests
@@ -78,12 +77,10 @@ else:
     start_date = datetime.strptime(args.start,'%Y-%m-%d')
     end_date = datetime.strptime(args.end,'%Y-%m-%d')
 
-
    
-#pat = open("/etc/oura/PAT.txt","r").read(32)
-pat = open("PAT.txt","r").read(32)
+pat = open("/etc/oura/PAT.txt","r").read(32)
 
-client_ouradb = InfluxDBClient(host="192.168.42.107", port=8086, database="ouradbTEST2")
+client_ouradb = InfluxDBClient(host="localhost", port=8086, database="ouradb")
 
 # If you wish to reduce queries to the Oura API, you can uncomment the following steps.
 # This way no more queries are done after data has already been received that day.

--- a/oura/oura_post_to_influxdb.py
+++ b/oura/oura_post_to_influxdb.py
@@ -27,7 +27,6 @@ def get_data_one_day(date,pat):
     sleep_data.pop('low_battery_alert', None)
     sleep_data.pop('type', None)
     sleep_data.pop('readiness', None)
-    readiness_data.pop('contributors', None)
     
  
 

--- a/oura/oura_post_to_influxdb.py
+++ b/oura/oura_post_to_influxdb.py
@@ -1,3 +1,5 @@
+#!/bin/python3
+
 from datetime import datetime, timedelta
 from influxdb import InfluxDBClient
 import requests
@@ -28,6 +30,7 @@ def get_data_one_day(date,pat):
     sleep_data.pop('type', None)
     sleep_data.pop('readiness', None)
     readiness_data.pop('contributors', None)
+    
  
 
 
@@ -40,7 +43,7 @@ def get_data_one_day(date,pat):
              "time": data['bedtime_end'],
              "fields": data
     },]
-
+    
     return post_data
 
 
@@ -77,9 +80,10 @@ else:
 
 
    
-pat = open("/etc/oura/PAT.txt","r").read(32)
+#pat = open("/etc/oura/PAT.txt","r").read(32)
+pat = open("PAT.txt","r").read(32)
 
-client_ouradb = InfluxDBClient(host="localhost", port=8086, database="ouradb")
+client_ouradb = InfluxDBClient(host="192.168.42.107", port=8086, database="ouradbTEST2")
 
 # If you wish to reduce queries to the Oura API, you can uncomment the following steps.
 # This way no more queries are done after data has already been received that day.
@@ -99,6 +103,7 @@ client_ouradb = InfluxDBClient(host="localhost", port=8086, database="ouradb")
 while start_date <= end_date:
     data = get_data_one_day(end_date.strftime('%Y-%m-%d'),pat)
     client_ouradb.write_points(data)
+    #print(end_date)
     #print(json.dumps(data, indent=4))
     end_date = end_date - timedelta(days=1)
 

--- a/oura/oura_post_to_influxdb.py
+++ b/oura/oura_post_to_influxdb.py
@@ -1,4 +1,3 @@
-#!/bin/python3
 from datetime import datetime, timedelta
 from influxdb import InfluxDBClient
 import requests

--- a/oura/oura_query.py
+++ b/oura/oura_query.py
@@ -28,6 +28,11 @@ def fetch_data(start, end, datatype, pat_data):
                 if v == "long_sleep":
                     resp = resp2
             indexstart+= 1
+    
+    #Adds the contributors section at level 0 of our readiness json. Includes stats like hrv and sleep balance
+    if datatype == 'daily_readiness':
+        resp2 = response["data"][0]["contributors"]
+        resp.update(resp2)
         
     # All data should be consistent in influxdb, so turn ints to floats
     resp = {k:float(v) if type(v) == int else v for k,v in resp.items()}

--- a/oura/oura_query.py
+++ b/oura/oura_query.py
@@ -1,3 +1,5 @@
+#!/bin/python3
+
 from datetime import datetime, timedelta
 import requests
 import argparse
@@ -11,16 +13,27 @@ def fetch_data(start, end, datatype, pat_data):
     headers = {"Authorization": f"Bearer {pat_data}"}
     params = {"start_date": f"{start.strftime('%Y-%m-%d')}", 'end_date': f"{end.strftime('%Y-%m-%d')}"}
     response = requests.request('GET', url, headers=headers, params=params).json()
-    resp = response["data"][0]
 
     if not response["data"]:
         print("No {} data yet for time window, exiting".format(datatype))
         exit()
 
-   
+    resp = response["data"][0]
 
+    #If we're looking for sleep...cycles through the items in response dictionary, finds the one that contains long_sleep, sets the active resp to that section. Otherwise naps make amess of the data.
+    indexstart = 0
+    indexceiling = len(response["data"]) - 1 
+    if datatype == 'sleep':
+        while indexstart <= indexceiling:
+            resp2 = response["data"][indexstart]
+            for k, v in resp2.items():
+                if v == "long_sleep":
+                    resp = resp2
+            indexstart+= 1
+        
     # All data should be consistent in influxdb, so turn ints to floats
     resp = {k:float(v) if type(v) == int else v for k,v in resp.items()}
+    print(end)
     return resp
 
 

--- a/oura/oura_query.py
+++ b/oura/oura_query.py
@@ -1,4 +1,3 @@
-#!/bin/python3
 from datetime import datetime, timedelta
 import requests
 import argparse
@@ -32,7 +31,6 @@ def fetch_data(start, end, datatype, pat_data):
         
     # All data should be consistent in influxdb, so turn ints to floats
     resp = {k:float(v) if type(v) == int else v for k,v in resp.items()}
-    print(end)
     return resp
 
 

--- a/oura/oura_query.py
+++ b/oura/oura_query.py
@@ -1,5 +1,4 @@
 #!/bin/python3
-
 from datetime import datetime, timedelta
 import requests
 import argparse

--- a/oura/oura_query.py
+++ b/oura/oura_query.py
@@ -32,6 +32,7 @@ def fetch_data(start, end, datatype, pat_data):
     #Adds the contributors section at level 0 of our readiness json. Includes stats like hrv and sleep balance
     if datatype == 'daily_readiness':
         resp2 = response["data"][0]["contributors"]
+        resp.pop('contributors', None)
         resp.update(resp2)
         
     # All data should be consistent in influxdb, so turn ints to floats


### PR DESCRIPTION
The last commit would inadvertently select naps sometimes as the only sleep data[0] vs data[1] or data[2]

This commit is updated to peer into the sections searching for long_sleep and selecting that section as the sleep data

I ran it against 6 months of data and didnt get any '20 minutes of sleep' days in there